### PR TITLE
change comm. structure, reduce duplicate topic overhead

### DIFF
--- a/node/formation_node.cpp
+++ b/node/formation_node.cpp
@@ -156,15 +156,21 @@ int main(int argc, char **argv)
     ros::param::get("delay_step", MAV::delay_step);
 
     //Subscriber
-    MAV mav[5] = {MAV(nh, "/leader_pose", 0),
-                  MAV(nh, "/MAV1/mavros/local_position/pose_initialized", 1),
-                  MAV(nh, "/MAV2/mavros/local_position/pose_initialized", 2),
-                  MAV(nh, "/MAV3/mavros/local_position/pose_initialized", 3),
-                  MAV(nh, "/MAV4/mavros/local_position/pose_initialized", 4)};
+    if(MAV::UAV_ID == 1){
+        MAV mav[3] = {MAV(nh, "/leader_pose", 0),
+                      MAV(nh, "/MAV1/mavros/local_position/pose_initialized", 1),
+                      MAV(nh, "local/MAV2/local_position/pose_initialized", 2)};
+    }else if(MAV::UAV_ID == 2){
+        MAV mav[3] = {MAV(nh, "/leader_pose", 0),
+                      MAV(nh, "local/MAV1/local_position/pose_initialized", 1),
+                      MAV(nh, "/MAV2/mavros/local_position/pose_initialized", 2)};
+    }
+    
+
     ros::Subscriber leader_vel_sub = nh.subscribe<geometry_msgs::TwistStamped>("/leader_vel", 10, leader_vel_cb);
     ros::Subscriber uav_start_sub = nh.subscribe<std_msgs::Int32>("/uav_start", 10, start_cb);
     //Publisher    
-    ros::Publisher desired_vel_pub = nh.advertise<geometry_msgs::TwistStamped>("desired_velocity_raw", 100);
+    ros::Publisher desired_vel_pub = nh.advertise<geometry_msgs::TwistStamped>("desired_velocity_raw", 10);
 
 
     XmlRpc::XmlRpcValue laplacian_param;

--- a/node/leader_pose_node.cpp
+++ b/node/leader_pose_node.cpp
@@ -180,7 +180,7 @@ int main(int argc, char **argv)
   ros::Publisher uav_takeoff_pub = nh.advertise<std_msgs::Int32>("/uav_takeoff", 10);
 
 
-  ros::Subscriber target_pose_sub = nh.subscribe<geometry_msgs::PoseStamped>("/MAV6/mavros/local_position/pose_initialized", 10, target_pose_cb);
+  ros::Subscriber target_pose_sub = nh.subscribe<geometry_msgs::PoseStamped>("local/MAV6/local_position/pose_initialized", 10, target_pose_cb);
   ros::Subscriber target_vel_sub = nh.subscribe<geometry_msgs::TwistStamped>("/MAV6/mavros/local_position/velocity_local", 10, target_vel_cb);
 
   ros::Rate loop_rate(CONTROL_HZ);

--- a/node/velocity_cbf_generator_node.cpp
+++ b/node/velocity_cbf_generator_node.cpp
@@ -329,11 +329,18 @@ int main(int argc, char **argv)
     ros::param::get("MAV_safe_D", MAV_SafeDistance);
 
 
-    CBF_object cbO[5] = {CBF_object(nh, "/leader_pose",obstacle_SafeDistance, obstacle_Gamma, 0),
+    if(CBF_object::self_id == 1){
+        CBF_object cbO[4] = {CBF_object(nh, "/leader_pose",obstacle_SafeDistance, obstacle_Gamma, 0),
                          CBF_object(nh, "/MAV1/mavros/local_position/pose_initialized", MAV_SafeDistance, MAV_Gamma, 1),
+                         CBF_object(nh, "local/MAV2/local_position/pose_initialized", MAV_SafeDistance, MAV_Gamma, 2),
+                         CBF_object(nh, "local/MAV6/local_position/pose_initialized", MAV_SafeDistance, MAV_Gamma, 4)};
+    }else if(CBF_object::self_id == 2){
+        CBF_object cbO[4] = {CBF_object(nh, "/leader_pose",obstacle_SafeDistance, obstacle_Gamma, 0),
+                         CBF_object(nh, "local/MAV1/local_position/pose_initialized", MAV_SafeDistance, MAV_Gamma, 1),
                          CBF_object(nh, "/MAV2/mavros/local_position/pose_initialized", MAV_SafeDistance, MAV_Gamma, 2),
-                         CBF_object(nh, "/MAV3/mavros/local_position/pose_initialized", MAV_SafeDistance, MAV_Gamma, 3),
-                         CBF_object(nh, "/MAV6/mavros/local_position/pose_initialized", MAV_SafeDistance, MAV_Gamma, 4)};
+                         CBF_object(nh, "local/MAV6/local_position/pose_initialized", MAV_SafeDistance, MAV_Gamma, 4)};
+    }
+   
 
     ROS_INFO("Wait for pose and desired input init");
     while (ros::ok() && (!desired_input_init || !pose_init)) {


### PR DESCRIPTION
Receive all neighbors position info in gps_init and broadcast then locally to reduce duplicate communication connection of the same topic. Ideally reduce 8 global connection to 4. Deleted some unused subscriber like MAV3, MAV4 to reduce redundancy comm. channel dunno if it'ill affect the code.